### PR TITLE
chore: add CLAUDE.md with path-scoped rules

### DIFF
--- a/.claude/rules/accessibility.md
+++ b/.claude/rules/accessibility.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "docs/**/*.html"
+  - "docs/css/**"
+  - "docs/js/**"
+---
+
+# Accessibility Rules (WCAG AA)
+
+## Requirements
+
+- Color contrast ratio >= 4.5:1 for all text
+- All interactive elements must have `:focus-visible` styles
+- ARIA labels on icon-only buttons and non-semantic elements
+- Keyboard navigation works (Tab, Enter, Escape, Arrow keys)
+- No information conveyed by color alone
+- `prefers-reduced-motion` respected for animations
+- Images must have meaningful alt text
+
+## Testing
+
+Check contrast with browser DevTools or https://webaim.org/resources/contrastchecker/
+Tab through the page to verify focus order makes sense.

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "docs/js/i18n.js"
+  - "docs/index.html"
+---
+
+# Internationalization Rules
+
+## Adding New Text
+
+1. Add a translation key to ALL 13 languages in `docs/js/i18n.js`
+2. Reference the key in HTML via the i18n data attribute
+3. Never hardcode user-visible text in HTML -- always use i18n keys
+4. Language preference persists in localStorage
+
+## Supported Languages
+
+English, Portuguese, Spanish, French, German, Dutch, Turkish, Russian,
+Ukrainian, Indonesian, Vietnamese, and 2 more.
+
+## If adding a new language
+
+Add a new object in `i18n.js` following the existing pattern. Add the
+language flag icon to the language picker in `index.html`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# RavenHUD Website
+
+> Static site. No build tools, no npm, pure HTML/CSS/JS.
+> Changes to `docs/` auto-deploy to GitHub Pages on push to `master`.
+
+## Pre-Flight Checklist
+
+```bash
+git fetch origin && git branch --show-current && git status
+```
+
+No typecheck needed -- this is vanilla HTML/CSS/JS.
+
+---
+
+## Hard Rules
+
+- **NEVER** commit to `master` directly for features -- create a branch and PR
+- **NEVER** break accessibility (WCAG AA contrast, keyboard nav, ARIA labels)
+- **NEVER** add external JavaScript libraries -- this site has zero dependencies
+- **NEVER** hardcode version numbers -- the site fetches from GitHub API dynamically
+
+---
+
+## Architecture
+
+```
+docs/                    # GitHub Pages root (auto-deploys)
+├── index.html           # Single-page site
+├── css/style.css        # All styles (CSS custom properties)
+├── js/
+│   ├── main.js          # Core functionality (release fetch, lightbox, etc.)
+│   └── i18n.js          # 13-language translation system
+├── assets/              # Images, GIFs, videos
+├── demo/                # Interactive demo page
+└── auth/discord/        # OAuth2 callback
+```
+
+- **No build process** -- edit files directly, they deploy as-is
+- **No npm/node** -- zero dependencies
+- **i18n** -- translations in `js/i18n.js`, keys referenced in HTML via data attributes
+
+---
+
+## Design System
+
+CSS custom properties in `docs/css/style.css`:
+
+```css
+--bg-primary: #1a1614      --text-primary: #e8dcc8
+--accent-primary: #c9a959  --success: #7cb342
+```
+
+Use existing variables -- never hardcode colors. Warm fantasy theme (gold/brown, not purple).
+
+---
+
+## Git Workflow
+
+```
+feature-branch -> PR -> master -> auto-deploy (GitHub Pages)
+```
+
+Single branch model. All work targets `master`.
+Commit format: `<type>: <description>` (no scope required for this repo).
+Body **recommended** for feat/fix. Warning mode -- not enforced.
+
+Setup hooks: `./scripts/setup-hooks.sh`
+
+---
+
+## CI/CD
+
+| Workflow | Trigger | Action |
+|----------|---------|--------|
+| `deploy-pages.yml` | Push to master (docs/**) | Deploy to GitHub Pages |
+| `discord-announce.yml` | Release published | Post to Discord webhook |
+| `upload-asset.yml` | Manual dispatch | Upload build artifact to release |
+
+---
+
+## Local Preview
+
+```bash
+# Python
+python -m http.server 8000 --directory docs
+
+# Or Node (if available)
+npx serve docs
+```
+
+Open `http://localhost:8000` in browser.
+
+---
+
+## When Uncertain
+
+1. Check existing patterns in `docs/js/main.js`
+2. Verify accessibility -- contrast, keyboard nav, ARIA
+3. Test i18n -- does the new text have translation keys?
+4. Preview locally before pushing


### PR DESCRIPTION
## Summary
- Add CLAUDE.md (~80 lines) with hard rules, architecture, design system reference
- Add 2 path-scoped rules: accessibility (WCAG AA), i18n (translation system)
- No build tools, no npm — static site conventions documented

## Test plan
- [ ] Start new Claude Code session, verify CLAUDE.md loads
- [ ] Touch an HTML file, verify accessibility rule loads
- [ ] Touch i18n.js, verify i18n rule loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)