### PR TITLE
feat: worldmap edit labeling, lightbox, and submission fixes

### DIFF
--- a/.github/workflows/marker-submissions.yml
+++ b/.github/workflows/marker-submissions.yml
@@ -74,15 +74,19 @@ jobs:
 
             // Trusted authors — check authorName inside the JSON payload,
             // NOT the GitHub issue author (issues are created via Corvid proxy)
-            const TRUSTED_AUTHORS = ['Azurak'];
+            const TRUSTED_AUTHORS = ['Azurak', 'Pixelated'];
             const markerAuthor = markers[0]?.authorName || '';
             const isTrusted = TRUSTED_AUTHORS.some(
               a => a.toLowerCase() === markerAuthor.toLowerCase()
             );
 
+            // Detect if this is an edit (correction) submission
+            const isEdit = markers.some(m => m.correction);
+
             // Collect unique categories and floors
             const categories = [...new Set(markers.map(m => m.category).filter(Boolean))];
             const labels = [isTrusted ? 'approved' : 'needs-review'];
+            if (isEdit) labels.push('edit');
             for (const cat of categories) {
               labels.push(`cat:${cat}`);
             }
@@ -177,6 +181,7 @@ jobs:
             }
 
             const count = markers.length;
+            const editTag = isEdit ? ' (edit)' : '';
             const catList = categories.map(c => `\`${c}\``).join(', ');
             const ssStatus = screenshotUrl
               ? `\n📷 [Screenshot attached](${screenshotUrl})`
@@ -186,12 +191,12 @@ jobs:
 
             const commentBody = isTrusted
               ? [
-                  `✅ **Parsed ${count} marker(s)** in ${catList}${ssStatus}`,
+                  `✅ **Parsed ${count} marker${editTag}** in ${catList}${ssStatus}`,
                   '',
-                  `🌟 **Auto-approved** — trusted contributor @${issueAuthor}. Ingestion will run automatically.`
+                  `🌟 **Auto-approved** — trusted contributor. Ingestion will run automatically.`
                 ].join('\n')
               : [
-                  `✅ **Parsed ${count} marker(s)** in ${catList}${ssStatus}`,
+                  `✅ **Parsed ${count} marker${editTag}** in ${catList}${ssStatus}`,
                   '',
                   'A maintainer will review this submission. To approve:',
                   '- Comment `/approve` to add the `approved` label',

--- a/docs/worldmap/index.html
+++ b/docs/worldmap/index.html
@@ -131,6 +131,12 @@
     <button class="btn-suggest-edit" id="btn-suggest-edit">Suggest Edit</button>
   </div>
 
+  <!-- Screenshot Lightbox -->
+  <div class="lightbox-overlay" id="lightbox-overlay" hidden>
+    <img id="lightbox-img" alt="Screenshot" />
+    <button class="lightbox-close" id="lightbox-close" aria-label="Close">&times;</button>
+  </div>
+
   <!-- Scripts -->
   <script src="../js/lib/leaflet.js"></script>
   <script src="../js/lib/leaflet-rastercoords.js"></script>

--- a/docs/worldmap/worldmap.css
+++ b/docs/worldmap/worldmap.css
@@ -677,3 +677,47 @@ body {
     width: 280px;
   }
 }
+
+/* ============================================================
+   Lightbox
+   ============================================================ */
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.lightbox-overlay[hidden] {
+  display: none;
+}
+
+.lightbox-overlay img {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 6px;
+  cursor: default;
+  box-shadow: 0 4px 32px rgba(0, 0, 0, 0.6);
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 32px;
+  cursor: pointer;
+  opacity: 0.7;
+  line-height: 1;
+}
+
+.lightbox-close:hover {
+  opacity: 1;
+}

--- a/docs/worldmap/worldmap.js
+++ b/docs/worldmap/worldmap.js
@@ -43,7 +43,7 @@ var CATEGORIES = {
   expedition: { label: 'Expeditions', emoji: '\uD83E\uDDED', group: 'Exploration' },
   creature_spawn: { label: 'Elite Spawns', emoji: '\uD83D\uDC80', group: 'Exploration' },
   reputation_shiny: { label: 'Reputation (Shiny)', emoji: '\u2728', group: 'Reputation' },
-  npc_reputation: { label: 'Reputation (NPC)', emoji: '\uD83D\uDC64', group: 'Reputation' }
+  npc_reputation: { label: 'Reputation (NPC)', emoji: '\uD83D\uDCAC', group: 'Reputation' }
 };
 
 // Category groups for sidebar ordering
@@ -248,6 +248,9 @@ async function init() {
     visibility[key] = true;
   }
 
+  // Apply any locally-persisted edits before rendering
+  applyLocalEdits();
+
   buildSidebar();
   renderMarkers();
   updateStats();
@@ -404,6 +407,9 @@ function showDetail(m) {
     img.src = ssUrl;
     img.alt = m.name + ' screenshot';
     img.loading = 'lazy';
+    img.style.cursor = 'pointer';
+    img.title = 'Click to enlarge';
+    img.addEventListener('click', function () { openLightbox(ssUrl); });
     ssContainer.appendChild(img);
   }
 
@@ -416,6 +422,23 @@ function showDetail(m) {
   map.panTo(latlng);
 }
 
+// ---------------------------------------------------------------------------
+// Lightbox (click-to-zoom screenshots)
+// ---------------------------------------------------------------------------
+
+function openLightbox(imageUrl) {
+  var overlay = document.getElementById('lightbox-overlay');
+  var img = document.getElementById('lightbox-img');
+  img.src = imageUrl;
+  overlay.hidden = false;
+}
+
+function closeLightbox() {
+  var overlay = document.getElementById('lightbox-overlay');
+  overlay.hidden = true;
+  document.getElementById('lightbox-img').src = '';
+}
+
 function initDetailPanel() {
   document.getElementById('detail-close').addEventListener('click', function () {
     document.getElementById('detail-panel').hidden = true;
@@ -426,6 +449,13 @@ function initDetailPanel() {
     if (currentDetailMarker) {
       openModalForEdit(currentDetailMarker);
     }
+  });
+
+  // Lightbox close handlers
+  var lbOverlay = document.getElementById('lightbox-overlay');
+  document.getElementById('lightbox-close').addEventListener('click', closeLightbox);
+  lbOverlay.addEventListener('click', function (e) {
+    if (e.target === lbOverlay) closeLightbox();
   });
 }
 
@@ -789,8 +819,8 @@ function compressToWebP(blob) {
     img.onload = function () {
       URL.revokeObjectURL(objectUrl);
       var canvas = document.createElement('canvas');
-      // Cap at 1280px wide to keep size reasonable
-      var maxW = 1280;
+      // Match companion app: 600px wide, quality 0.55 — keeps base64 under GitHub limit
+      var maxW = 600;
       var w = img.width;
       var h = img.height;
       if (w > maxW) {
@@ -800,7 +830,7 @@ function compressToWebP(blob) {
       canvas.width = w;
       canvas.height = h;
       canvas.getContext('2d').drawImage(img, 0, 0, w, h);
-      var dataUrl = canvas.toDataURL('image/webp', 0.8);
+      var dataUrl = canvas.toDataURL('image/webp', 0.55);
       resolve(dataUrl);
     };
     img.onerror = function () {
@@ -865,6 +895,47 @@ function validateForm() {
   document.getElementById('btn-create-issue').disabled = !valid;
 }
 
+// ---------------------------------------------------------------------------
+// Local edit persistence (localStorage)
+// ---------------------------------------------------------------------------
+
+var LOCAL_EDITS_KEY = 'rhud_marker_edits';
+
+function getLocalEdits() {
+  try {
+    return JSON.parse(localStorage.getItem(LOCAL_EDITS_KEY) || '{}');
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveLocalEdit(markerId, fields) {
+  var edits = getLocalEdits();
+  edits[markerId] = fields;
+  localStorage.setItem(LOCAL_EDITS_KEY, JSON.stringify(edits));
+}
+
+function applyLocalEdits() {
+  var edits = getLocalEdits();
+  var keys = Object.keys(edits);
+  if (keys.length === 0) return;
+
+  for (var m of allMarkers) {
+    if (edits[m.id]) {
+      var e = edits[m.id];
+      if (e.name) m.name = e.name;
+      if (e.x != null) m.x = e.x;
+      if (e.y != null) m.y = e.y;
+      if (e.description != null) m.description = e.description;
+      if (e.region != null) m.region = e.region;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Submit / Edit
+// ---------------------------------------------------------------------------
+
 function submitToCorvid() {
   if (!discordUser || !submitCoords) return;
 
@@ -878,6 +949,8 @@ function submitToCorvid() {
   btn.disabled = true;
   btn.textContent = 'Submitting...';
 
+  var isEdit = modalMode === 'edit' && editingMarker;
+
   var markerPayload = {
     category: category,
     name: name,
@@ -888,12 +961,29 @@ function submitToCorvid() {
   if (description) markerPayload.description = description;
   if (region) markerPayload.region = region;
 
+  // For edits: include original ID and correction flag so ingestion updates in-place
+  if (isEdit) {
+    markerPayload.id = editingMarker.id;
+    markerPayload.correction = true;
+  }
+
   var body = {
     markers: [markerPayload],
     authorName: discordUser.globalName || discordUser.username,
     authorDiscordId: discordUser.id
   };
   if (pendingScreenshot) body.screenshot = pendingScreenshot;
+
+  // For edits: include original values so the issue can show what changed
+  if (isEdit) {
+    body.originalMarker = {
+      name: editingMarker.name,
+      x: editingMarker.x,
+      y: editingMarker.y,
+      description: editingMarker.description || '',
+      region: editingMarker.region || ''
+    };
+  }
 
   fetch(CORVID_API_URL + '/api/markers/submit', {
     method: 'POST',
@@ -909,6 +999,29 @@ function submitToCorvid() {
       if (result.ok && result.data.success) {
         btn.textContent = 'Submitted!';
         btn.classList.add('btn-success');
+
+        // Persist edit locally so the user sees their change immediately
+        if (isEdit) {
+          saveLocalEdit(editingMarker.id, {
+            name: name,
+            x: submitCoords.x,
+            y: submitCoords.y,
+            description: description,
+            region: region
+          });
+          // Apply to in-memory marker too
+          var m = allMarkers.find(function (mk) { return mk.id === editingMarker.id; });
+          if (m) {
+            m.name = name;
+            m.x = submitCoords.x;
+            m.y = submitCoords.y;
+            m.description = description;
+            m.region = region;
+          }
+          renderMarkers();
+          updateStats();
+        }
+
         setTimeout(function () { closeModal(); }, 1500);
       } else {
         throw new Error(result.data.error || 'Submission failed');


### PR DESCRIPTION
## Summary
- **Edit submissions** now labeled differently: issue title says "Edit:", body shows a before/after diff table, `correction: true` in JSON for ingestion, `edit` label auto-added
- **Local edit persistence**: edits saved to localStorage so user sees their changes immediately without waiting for ingestion
- **Screenshot lightbox**: clicking a screenshot in the detail panel opens a fullscreen overlay (like the companion app)
- **NPC emoji**: changed from 👤 (dark, hard to see) to 💬 (speech bubble, visible)
- **Screenshot compression**: reduced to 600px wide / 0.55 quality (matches companion app's sharp settings) — fixes GitHub issue body size limit error
- **Auto-approve**: added Pixelated to TRUSTED_AUTHORS

## Test plan
- [ ] Submit a new marker with screenshot — should succeed
- [ ] Submit an edit — issue should have "Edit:" title and diff table
- [ ] Click a screenshot in detail panel — should open lightbox
- [ ] Close lightbox by clicking X or background
- [ ] Edit a marker, reload page — edit should persist
- [ ] NPC markers show 💬 emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)