### PR TITLE
chore: add Kullion to trusted submitters

### DIFF
--- a/.github/workflows/marker-submissions.yml
+++ b/.github/workflows/marker-submissions.yml
@@ -74,7 +74,7 @@ jobs:
 
             // Trusted authors — check authorName inside the JSON payload,
             // NOT the GitHub issue author (issues are created via Corvid proxy)
-            const TRUSTED_AUTHORS = ['Azurak', 'Pixelated'];
+            const TRUSTED_AUTHORS = ['Azurak', 'Kullion', 'Pixelated'];
             const markerAuthor = markers[0]?.authorName || '';
             const isTrusted = TRUSTED_AUTHORS.some(
               a => a.toLowerCase() === markerAuthor.toLowerCase()


### PR DESCRIPTION
## Summary
- Adds Kullion to the `TRUSTED_AUTHORS` array in the marker submissions workflow
- Azurak vouched for him — his submissions will now auto-approve and ingest without manual review

## Test plan
- [ ] Wait for a Kullion submission and confirm it gets the `approved` label automatically


🤖 Generated with [Claude Code](https://claude.com/claude-code)