### PR TITLE
feat: save indicator on collection toggle

### DIFF
--- a/docs/worldmap/worldmap.css
+++ b/docs/worldmap/worldmap.css
@@ -537,6 +537,16 @@ body {
 .shiny-check-label input:checked + span {
   color: #7cb342;
 }
+.save-flash {
+  margin-left: auto;
+  font-size: 11px;
+  color: #7cb342;
+  animation: flash-in 0.3s ease-out;
+}
+@keyframes flash-in {
+  from { opacity: 0; transform: translateY(2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 .marker-item.shiny-collected {
   opacity: 0.5;
 }

--- a/docs/worldmap/worldmap.js
+++ b/docs/worldmap/worldmap.js
@@ -756,10 +756,14 @@ function showDetail(m) {
       '<label class="shiny-check-label">' +
       '<input type="checkbox" ' + (isCollected ? 'checked' : '') + ' />' +
       '<span>' + (isCollected ? 'Collected' : 'Mark as Collected') + '</span>' +
+      '<span class="save-flash" style="display:none">Saved</span>' +
       '</label>';
     shinySection.querySelector('input').addEventListener('change', function () {
       var nowCollected = toggleShinyCollected(m.id);
       this.nextElementSibling.textContent = nowCollected ? 'Collected' : 'Mark as Collected';
+      var flash = shinySection.querySelector('.save-flash');
+      flash.style.display = '';
+      setTimeout(function () { flash.style.display = 'none'; }, 1500);
       renderMarkers();
       updateSidebar();
     });


### PR DESCRIPTION
## Summary
- Brief "Saved" flash when toggling collection checklist confirms localStorage persistence

## Test plan
- [ ] Toggle a shiny/NPC marker — green "Saved" text flashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)