### PR TITLE
fix(ci): use SYNC_PAT for gh pr commands in sync-images

### DIFF
--- a/.github/workflows/sync-images.yml
+++ b/.github/workflows/sync-images.yml
@@ -178,4 +178,4 @@ jobs:
             echo "Created new PR on branch $BRANCH"
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}


### PR DESCRIPTION
## Summary
Swaps `GH_TOKEN: ${{ github.token }}` for `GH_TOKEN: ${{ secrets.SYNC_PAT }}` in [.github/workflows/sync-images.yml:181](.github/workflows/sync-images.yml#L181) so the cron can create PRs.

## Why
The enterprise policy disables write workflow permissions (`Write permissions for workflows are disabled by the enterprise`), which blocks the Actions bot from running `gh pr create`. Even though the job declares `pull-requests: write`, the enterprise restriction takes precedence.

Branches were pushing fine for 5+ days (19 stale branches piled up, all now deleted), but PR creation was silently failing every night. Manually publishing the backlog via ravenhud#452 restored the master manifest to 20 archives, but the cron would break again tonight without this fix.

## The PAT
- Fine-grained PAT, 365-day expiry (max allowed)
- Scoped to only this repo (`Pix-Elated/ravenhud`)
- Permissions: Contents (write), Pull requests (write), Metadata (read-only)
- Stored as `SYNC_PAT` repo secret

## Test Plan
- [ ] After merge, dispatch sync-images.yml manually via `gh workflow run`
- [ ] Verify it opens a PR (not just pushes a branch)
- [ ] Confirm tomorrow's 3am UTC scheduled run succeeds

## Rotation reminder
PAT expires ~2027-04-05. Add a calendar reminder or a follow-up workflow to warn ~30 days before expiry.