### PR TITLE
feat(worldmap): browser fingerprint for ban-evasion detection

### DIFF
--- a/docs/worldmap/worldmap.css
+++ b/docs/worldmap/worldmap.css
@@ -1177,6 +1177,15 @@ body {
   font-weight: 600;
 }
 
+.identity-privacy {
+  font-size: 10px;
+  color: var(--text-tertiary, #8a8479);
+  line-height: 1.45;
+  margin-bottom: 16px;
+  padding: 6px 10px;
+  opacity: 0.85;
+}
+
 .identity-label {
   font-size: 11px;
   font-weight: 600;

--- a/docs/worldmap/worldmap.js
+++ b/docs/worldmap/worldmap.js
@@ -252,6 +252,77 @@ var banListCache = null;
 var IDENTITY_KEY = 'rhud_identity';
 var IDENTITY_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
 
+// ---------------------------------------------------------------------------
+// Browser Fingerprint (UEBA)
+// ---------------------------------------------------------------------------
+
+// Combines stable browser/device signals into a single hash. Used by Corvid's
+// submission logger to cluster evasion attempts across cleared cookies + cache.
+// Each signal contributes entropy; together we get enough stability to link
+// repeated visits from the same browser/machine even after identity changes.
+// ~30-40 bits of entropy in aggregate. Not unique per user but discriminative
+// enough for the "same person lying about their name" detection use case.
+var fingerprintCache = null;
+
+async function computeFingerprint() {
+  if (fingerprintCache) return fingerprintCache;
+
+  var signals = [];
+  signals.push(navigator.userAgent || '');
+  signals.push(navigator.language || '');
+  signals.push(navigator.languages ? navigator.languages.join(',') : '');
+  signals.push(screen.width + 'x' + screen.height + 'x' + (screen.colorDepth || 0));
+  signals.push(String(window.devicePixelRatio || 1));
+  signals.push(Intl.DateTimeFormat().resolvedOptions().timeZone || '');
+  signals.push(String(navigator.hardwareConcurrency || 0));
+  signals.push(String(navigator.deviceMemory || 0));
+  signals.push(String(new Date().getTimezoneOffset()));
+
+  // Canvas fingerprint — text rendered to a canvas produces slightly different
+  // pixels on every GPU / driver / font stack combination.
+  try {
+    var canvas = document.createElement('canvas');
+    canvas.width = 240;
+    canvas.height = 60;
+    var ctx = canvas.getContext('2d');
+    ctx.textBaseline = 'top';
+    ctx.font = "14px 'Arial'";
+    ctx.fillStyle = '#f60';
+    ctx.fillRect(0, 0, 100, 20);
+    ctx.fillStyle = '#069';
+    ctx.fillText('RavenHUD fingerprint \uD83D\uDC26', 2, 15);
+    ctx.fillStyle = 'rgba(102, 204, 0, 0.7)';
+    ctx.fillText('RavenHUD fingerprint \uD83D\uDC26', 4, 17);
+    signals.push(canvas.toDataURL());
+  } catch (e) { /* canvas blocked, skip */ }
+
+  // WebGL renderer — GPU identification string, very stable
+  try {
+    var gl = document.createElement('canvas').getContext('webgl');
+    if (gl) {
+      var ext = gl.getExtension('WEBGL_debug_renderer_info');
+      if (ext) {
+        signals.push(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) || '');
+        signals.push(gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) || '');
+      }
+    }
+  } catch (e) { /* WebGL blocked, skip */ }
+
+  var combined = signals.join('||');
+  var buf = new TextEncoder().encode(combined);
+  try {
+    var hash = await crypto.subtle.digest('SHA-256', buf);
+    var hex = Array.from(new Uint8Array(hash))
+      .map(function (b) { return b.toString(16).padStart(2, '0'); })
+      .join('');
+    fingerprintCache = 'fp_' + hex.slice(0, 32);
+  } catch (e) {
+    // Fallback for browsers without SubtleCrypto (extremely old)
+    fingerprintCache = 'fp_fallback_' + combined.length;
+  }
+  return fingerprintCache;
+}
+
 async function fetchBanList() {
   if (banListCache) return banListCache;
   // Prefer Corvid (sub-100ms, in-memory cache) so SSE invalidations are
@@ -349,6 +420,11 @@ function showIdentityPrompt() {
       '<div class="identity-subtitle">Please identify yourself to continue</div>' +
       '<div class="identity-warning">' +
       '<strong>Warning:</strong> Entering random letters, intentionally misrepresenting your guild, or otherwise attempting to circumvent the integrity of this check will result in a ban.' +
+      '</div>' +
+      '<div class="identity-privacy">' +
+      'By continuing, you acknowledge that your IP address, browser/device fingerprint, ' +
+      'user-agent, character name, and guild tag are logged for ban-evasion detection and ' +
+      'abuse prevention (retained up to 90 days). No third-party tracking.' +
       '</div>' +
       '<label class="identity-label">Character Name</label>' +
       '<input type="text" id="identity-char" class="identity-input" placeholder="Your in-game name" maxlength="30" />' +
@@ -581,6 +657,10 @@ async function init() {
     isNewIdentity = true;
   }
 
+  // Compute the browser fingerprint up-front so we can send it with the
+  // identity log. Used by Corvid's /cluster admin command to detect evasion.
+  var fingerprint = await computeFingerprint();
+
   // Log identity to Corvid — only on first visit or new identity, not every page load
   // Always check IP ban though (server-side — client can't know its own IP)
   try {
@@ -591,7 +671,9 @@ async function init() {
         characterName: identity.characterName,
         guildTag: identity.guildTag,
         timestamp: new Date().toISOString(),
-        isNewIdentity: isNewIdentity
+        isNewIdentity: isNewIdentity,
+        fingerprint: fingerprint,
+        discordId: discordUser ? discordUser.id : undefined
       })
     });
     var logData = await logRes.json();


### PR DESCRIPTION
## Summary
Sends a stable browser fingerprint with every `/api/bans/identity-log` POST so Corvid's `/cluster` admin command can link repeat visitors who clear cookies and lie about their name/guild.

## How it works
Combines ~10 browser/device signals into a SHA-256 hash:
- User-Agent + languages
- Screen dimensions + color depth + devicePixelRatio
- Timezone + timezone offset
- hardwareConcurrency + deviceMemory
- Canvas text rendering (GPU/driver/font-stack specific pixels)
- WebGL renderer + vendor

~30-40 bits of entropy combined. Not unique per user but discriminative enough to answer 'is this the same person who was just here under a different name?' — which is the actual use case.

## What admins see
After this ships, every worldmap visit populates the `fingerprint` field in Corvid's `submissions.json`. Run `/cluster seed:<fingerprint>` (or IP, character, guild, Discord ID) to see the full graph of identities linked to that fingerprint.

## Privacy
Added a disclosure line to the identity prompt naming what's logged (IP, fingerprint, UA, character, guild) and the 90-day retention window. No third-party tracking, no external script loads, all signals are computed client-side and hashed before transmission.

## Depends on
- Pix-Elated/corvid#214 (merged, deploying as v1.33.0). If Corvid's older version is live when this deploys, the extra `fingerprint` and `discordId` fields in the request body are ignored silently — no regression.

## Test Plan
- [ ] After deploy: visit worldmap, submit identity, open DevTools Network tab → inspect `identity-log` request body → confirm `fingerprint` field is present and stable across reloads
- [ ] Clear cookies + localStorage, submit DIFFERENT character name → fingerprint should stay the same
- [ ] Run `/cluster seed:<that-fingerprint>` in Discord → confirm both character names show up in the cluster